### PR TITLE
Fix race condition in the emit loop

### DIFF
--- a/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
+++ b/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
@@ -163,10 +163,8 @@ namespace SnowplowTracker.Emitters {
 				}
 				List<EventRow> events = new List<EventRow>();
 
-				if (emitLock != null)
-				{
-				    lock (emitLock)
-				    {
+				if (emitLock != null) {
+				    lock (emitLock) {
 					events = eventStore.GetDescEventRange (sendLimit);
 					Monitor.Pulse(emitLock);
 				    }
@@ -190,10 +188,8 @@ namespace SnowplowTracker.Emitters {
 							failure += result.rowIds.Count;
 						}
 					}
-					if (emitLock != null)
-		    			{
-						lock (emitLock)
-						{
+					if (emitLock != null) {
+						lock (emitLock) {
 					    		eventStore.DeleteEvents(eventsToDelete);
 					    		Monitor.Pulse(emitLock);
 						}

--- a/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
+++ b/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
@@ -182,8 +182,14 @@ namespace SnowplowTracker.Emitters {
 							failure += result.rowIds.Count;
 						}
 					}
-					
-					eventStore.DeleteEvents(eventsToDelete);
+					if (emitLock != null)
+		    			{
+						lock (emitLock)
+						{
+					    		eventStore.DeleteEvents(eventsToDelete);
+					    		Monitor.Pulse(emitLock);
+						}
+				    	}
 					
 					Log.Debug ("Emitter: event sending results.");
 					Log.Debug (" + Successful: " + success);

--- a/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
+++ b/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
@@ -161,7 +161,17 @@ namespace SnowplowTracker.Emitters {
 					Log.Debug ("Emitter: EmitLoop shutting down...");
 					break;
 				}
+				List<EventRow> events = new List<EventRow>();
 
+				// Send events!
+				if (emitLock != null)
+				{
+				    lock (emitLock)
+				    {
+					events = eventStore.GetDescEventRange (sendLimit);
+					Monitor.Pulse(emitLock);
+				    }
+				}
 				// Send events!
 				List<EventRow> events = eventStore.GetDescEventRange (sendLimit);
 				if (events.Count != 0) {

--- a/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
+++ b/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
@@ -163,7 +163,6 @@ namespace SnowplowTracker.Emitters {
 				}
 				List<EventRow> events = new List<EventRow>();
 
-				// Send events!
 				if (emitLock != null)
 				{
 				    lock (emitLock)
@@ -173,7 +172,6 @@ namespace SnowplowTracker.Emitters {
 				    }
 				}
 				// Send events!
-				List<EventRow> events = eventStore.GetDescEventRange (sendLimit);
 				if (events.Count != 0) {
 					Log.Debug ("Emitter: Event count: " + events.Count);
 					List<RequestResult> results = SendRequests (events);


### PR DESCRIPTION
The consume loop can race on grabbing sqllite.

We have other updates around the sqllite version and bringing this current