### PR TITLE
Update copyrights to 2022 (close #48)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2022 Snowplow Analytics Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Tested Platforms:
 
 ## Copyright and license
 
-The Snowplow Unity Tracker is copyright 2015-2021 Snowplow Analytics Ltd.
+The Snowplow Unity Tracker is copyright 2015-2022 Snowplow Analytics Ltd.
 
 Licensed under the **[Apache License, Version 2.0][license]** (the "License");
 you may not use this software except in compliance with the License.

--- a/SnowplowTracker.Tests/Assets/Tests/Events/TestEcommerceTransaction.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Events/TestEcommerceTransaction.cs
@@ -2,7 +2,7 @@
  * TestEcommerceTransaction.cs
  * SnowplowTrackerTests.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Events/TestEcommerceTransactionItem.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Events/TestEcommerceTransactionItem.cs
@@ -2,7 +2,7 @@
  * TestEcommerceTransactionItem.cs
  * SnowplowTrackerTests.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Events/TestPageView.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Events/TestPageView.cs
@@ -2,7 +2,7 @@
  * TestPageView.cs
  * SnowplowTrackerTests.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Events/TestScreenView.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Events/TestScreenView.cs
@@ -2,7 +2,7 @@
  * TestScreenView.cs
  * SnowplowTrackerTests.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Events/TestStructured.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Events/TestStructured.cs
@@ -2,7 +2,7 @@
  * TestStructured.cs
  * SnowplowTrackerTests.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Events/TestTiming.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Events/TestTiming.cs
@@ -2,7 +2,7 @@
  * TestTiming.cs
  * SnowplowTrackerTests.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Events/TestUnstructured.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Events/TestUnstructured.cs
@@ -2,7 +2,7 @@
  * TestUnstructured.cs
  * SnowplowTrackerTests.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestDesktopContext.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestDesktopContext.cs
@@ -2,7 +2,7 @@
  * TestDesktopContext.cs
  * SnowplowTrackerTests.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestGenericContext.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestGenericContext.cs
@@ -2,7 +2,7 @@
  * TestGenericContext.cs
  * SnowplowTrackerTests.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestGeoLocationContext.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestGeoLocationContext.cs
@@ -2,7 +2,7 @@
  * TestGeoLocationContext.cs
  * SnowplowTrackerTests.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestMobileContext.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestMobileContext.cs
@@ -2,7 +2,7 @@
  * TestMobileContext.cs
  * SnowplowTrackerTests.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestSessionContext.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Payloads/Contexts/TestSessionContext.cs
@@ -2,7 +2,7 @@
  * TestSessionContext.cs
  * SnowplowTrackerTests.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Payloads/TestSelfDescribingJson.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Payloads/TestSelfDescribingJson.cs
@@ -2,7 +2,7 @@
  * TestSelfDescribingJson.cs
  * SnowplowTrackerTests.Payloads
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/Payloads/TestTrackerPayload.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/Payloads/TestTrackerPayload.cs
@@ -2,7 +2,7 @@
  * TestTrackerPayload.cs
  * SnowplowTrackerTests.Payloads
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/TestHelpers/BaseEmitter.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/TestHelpers/BaseEmitter.cs
@@ -2,7 +2,7 @@
  * BaseEmitter.cs
  * SnowplowTrackerTests.TestHelpers
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/TestIntegration.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/TestIntegration.cs
@@ -2,7 +2,7 @@
  * TestIntegration.cs
  * SnowplowTrackerTests
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/TestSession.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/TestSession.cs
@@ -2,7 +2,7 @@
  * TestSession.cs
  * SnowplowTrackerTests
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/TestSubject.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/TestSubject.cs
@@ -2,7 +2,7 @@
  * TestSubject.cs
  * SnowplowTrackerTests
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/TestTracker.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/TestTracker.cs
@@ -2,7 +2,7 @@
  * TestTracker.cs
  * SnowplowTrackerTests
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker.Tests/Assets/Tests/TestUtils.cs
+++ b/SnowplowTracker.Tests/Assets/Tests/TestUtils.cs
@@ -2,7 +2,7 @@
  * TestUtils.cs
  * SnowplowTrackerTests
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -14,7 +14,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  * 
  * Authors: Joshua Beemster
- * Copyright: Copyright (c) 2015 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/SnowplowTracker/SnowplowTracker/Collections/ConcurrentQueue.cs
+++ b/SnowplowTracker/SnowplowTracker/Collections/ConcurrentQueue.cs
@@ -2,7 +2,7 @@
  * ConcurrentQueue.cs
  * SnowplowTracker.Collections
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Constants.cs
+++ b/SnowplowTracker/SnowplowTracker/Constants.cs
@@ -2,7 +2,7 @@
  * Constants.cs
  * SnowplowTracker
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Emitters/AbstractEmitter.cs
+++ b/SnowplowTracker/SnowplowTracker/Emitters/AbstractEmitter.cs
@@ -2,7 +2,7 @@
  * AbstractEmitter.cs
  * SnowplowTracker.Emitters
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
+++ b/SnowplowTracker/SnowplowTracker/Emitters/AsyncEmitter.cs
@@ -2,7 +2,7 @@
  * AsyncEmitter.cs
  * SnowplowTracker.Emitters
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Emitters/IEmitter.cs
+++ b/SnowplowTracker/SnowplowTracker/Emitters/IEmitter.cs
@@ -2,7 +2,7 @@
  * IEmitter.cs
  * SnowplowTracker.Emitters
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Emitters/SyncEmitter.cs
+++ b/SnowplowTracker/SnowplowTracker/Emitters/SyncEmitter.cs
@@ -2,7 +2,7 @@
  * AsyncEmitter.cs
  * SnowplowTracker.Emitters
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System.Collections.Generic;

--- a/SnowplowTracker/SnowplowTracker/Enums/DevicePlatforms.cs
+++ b/SnowplowTracker/SnowplowTracker/Enums/DevicePlatforms.cs
@@ -2,7 +2,7 @@
  * DevicePlatforms.cs
  * SnowplowTracker.Enums
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 namespace SnowplowTracker.Enums

--- a/SnowplowTracker/SnowplowTracker/Enums/HttpMethod.cs
+++ b/SnowplowTracker/SnowplowTracker/Enums/HttpMethod.cs
@@ -2,7 +2,7 @@
  * HttpMethod.cs
  * SnowplowTracker.Enums
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 namespace SnowplowTracker.Enums

--- a/SnowplowTracker/SnowplowTracker/Enums/HttpProtocol.cs
+++ b/SnowplowTracker/SnowplowTracker/Enums/HttpProtocol.cs
@@ -2,7 +2,7 @@
  * HttpProtocol.cs
  * SnowplowTracker.Enums
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 namespace SnowplowTracker.Enums

--- a/SnowplowTracker/SnowplowTracker/Enums/NetworkType.cs
+++ b/SnowplowTracker/SnowplowTracker/Enums/NetworkType.cs
@@ -2,7 +2,7 @@
  * NetworkType.cs
  * SnowplowTracker.Enums
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 namespace SnowplowTracker.Enums

--- a/SnowplowTracker/SnowplowTracker/Enums/StorageMechanism.cs
+++ b/SnowplowTracker/SnowplowTracker/Enums/StorageMechanism.cs
@@ -2,7 +2,7 @@
  * StorageMechanism.cs
  * SnowplowTracker.Enums
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 namespace SnowplowTracker.Enums

--- a/SnowplowTracker/SnowplowTracker/Events/AbstractEvent.cs
+++ b/SnowplowTracker/SnowplowTracker/Events/AbstractEvent.cs
@@ -2,7 +2,7 @@
  * EventBuilder.cs
  * SnowplowTracker.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Events/EcommerceTransaction.cs
+++ b/SnowplowTracker/SnowplowTracker/Events/EcommerceTransaction.cs
@@ -2,7 +2,7 @@
  * EcommerceTransaction.cs
  * SnowplowTracker.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Events/EcommerceTransactionItem.cs
+++ b/SnowplowTracker/SnowplowTracker/Events/EcommerceTransactionItem.cs
@@ -2,7 +2,7 @@
  * EcommerceTransactionItem.cs
  * SnowplowTracker.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Events/IEvent.cs
+++ b/SnowplowTracker/SnowplowTracker/Events/IEvent.cs
@@ -2,7 +2,7 @@
  * IEvent.cs
  * SnowplowTracker.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System.Collections.Generic;

--- a/SnowplowTracker/SnowplowTracker/Events/PageView.cs
+++ b/SnowplowTracker/SnowplowTracker/Events/PageView.cs
@@ -2,7 +2,7 @@
  * PageView.cs
  * SnowplowTracker.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Events/ScreenView.cs
+++ b/SnowplowTracker/SnowplowTracker/Events/ScreenView.cs
@@ -2,7 +2,7 @@
  * ScreenView.cs
  * SnowplowTracker.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Events/Structured.cs
+++ b/SnowplowTracker/SnowplowTracker/Events/Structured.cs
@@ -2,7 +2,7 @@
  * Structured.cs
  * SnowplowTracker.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Events/Timing.cs
+++ b/SnowplowTracker/SnowplowTracker/Events/Timing.cs
@@ -2,7 +2,7 @@
  * Timing.cs
  * SnowplowTracker.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Events/Unstructured.cs
+++ b/SnowplowTracker/SnowplowTracker/Events/Unstructured.cs
@@ -2,7 +2,7 @@
  * Unstructured.cs
  * SnowplowTracker.Events
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using SnowplowTracker.Payloads;

--- a/SnowplowTracker/SnowplowTracker/Log.cs
+++ b/SnowplowTracker/SnowplowTracker/Log.cs
@@ -2,7 +2,7 @@
  * Log.cs
  * SnowplowTracker
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Payloads/AbstractPayload.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/AbstractPayload.cs
@@ -2,7 +2,7 @@
  * AbstractPayload.cs
  * SnowplowTracker.Payloads
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System.Collections.Generic;

--- a/SnowplowTracker/SnowplowTracker/Payloads/Contexts/AbstractContext.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/Contexts/AbstractContext.cs
@@ -2,7 +2,7 @@
  * AbstractContext.cs
  * SnowplowTracker.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Payloads/Contexts/DesktopContext.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/Contexts/DesktopContext.cs
@@ -2,7 +2,7 @@
  * DesktopContext.cs
  * SnowplowTracker.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 namespace SnowplowTracker.Payloads.Contexts

--- a/SnowplowTracker/SnowplowTracker/Payloads/Contexts/GenericContext.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/Contexts/GenericContext.cs
@@ -2,7 +2,7 @@
  * GenericContext.cs
  * SnowplowTracker.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System.Collections.Generic;

--- a/SnowplowTracker/SnowplowTracker/Payloads/Contexts/GeoLocationContext.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/Contexts/GeoLocationContext.cs
@@ -2,7 +2,7 @@
  * GeoLocationContext.cs
  * SnowplowTracker.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 namespace SnowplowTracker.Payloads.Contexts

--- a/SnowplowTracker/SnowplowTracker/Payloads/Contexts/IContext.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/Contexts/IContext.cs
@@ -2,7 +2,7 @@
  * IContext.cs
  * SnowplowTracker.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System.Collections.Generic;

--- a/SnowplowTracker/SnowplowTracker/Payloads/Contexts/MobileContext.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/Contexts/MobileContext.cs
@@ -2,7 +2,7 @@
  * MobileContext.cs
  * SnowplowTracker.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using SnowplowTracker.Enums;

--- a/SnowplowTracker/SnowplowTracker/Payloads/Contexts/SessionContext.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/Contexts/SessionContext.cs
@@ -2,7 +2,7 @@
  * SessionContext.cs
  * SnowplowTracker.Payloads.Contexts
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using SnowplowTracker.Enums;

--- a/SnowplowTracker/SnowplowTracker/Payloads/IPayload.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/IPayload.cs
@@ -2,7 +2,7 @@
  * IPayload.cs
  * SnowplowTracker.Payloads
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Payloads/SelfDescribingJson.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/SelfDescribingJson.cs
@@ -2,7 +2,7 @@
  * SelfDescribingJson.cs
  * SnowplowTracker.Payloads
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Payloads/TrackerPayload.cs
+++ b/SnowplowTracker/SnowplowTracker/Payloads/TrackerPayload.cs
@@ -2,7 +2,7 @@
  * TrackerPayload.cs
  * SnowplowTracker.Payloads
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Requests/ReadyRequest.cs
+++ b/SnowplowTracker/SnowplowTracker/Requests/ReadyRequest.cs
@@ -2,7 +2,7 @@
  * GetRequest.cs
  * SnowplowTracker.Requests
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Requests/RequestResult.cs
+++ b/SnowplowTracker/SnowplowTracker/Requests/RequestResult.cs
@@ -2,7 +2,7 @@
  * RequestResult.cs
  * SnowplowTracker.Requests
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Session.cs
+++ b/SnowplowTracker/SnowplowTracker/Session.cs
@@ -2,7 +2,7 @@
  * Session.cs
  * SnowplowTracker
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System.Collections.Generic;

--- a/SnowplowTracker/SnowplowTracker/Storage/EventRow.cs
+++ b/SnowplowTracker/SnowplowTracker/Storage/EventRow.cs
@@ -2,7 +2,7 @@
  * EventRow.cs
  * SnowplowTracker.Storage
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Storage/EventStore.cs
+++ b/SnowplowTracker/SnowplowTracker/Storage/EventStore.cs
@@ -2,7 +2,7 @@
  * EventStore.cs
  * SnowplowTracker.Storage
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Storage/IStore.cs
+++ b/SnowplowTracker/SnowplowTracker/Storage/IStore.cs
@@ -2,7 +2,7 @@
  * EventStore.cs
  * SnowplowTracker.Storage
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Subject.cs
+++ b/SnowplowTracker/SnowplowTracker/Subject.cs
@@ -2,7 +2,7 @@
  * Subject.cs
  * SnowplowTracker
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Tracker.cs
+++ b/SnowplowTracker/SnowplowTracker/Tracker.cs
@@ -2,7 +2,7 @@
  * Tracker.cs
  * SnowplowTracker
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Utils.cs
+++ b/SnowplowTracker/SnowplowTracker/Utils.cs
@@ -2,7 +2,7 @@
  * Utils.cs
  * SnowplowTracker
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;

--- a/SnowplowTracker/SnowplowTracker/Version.cs
+++ b/SnowplowTracker/SnowplowTracker/Version.cs
@@ -2,7 +2,7 @@
  * Version.cs
  * SnowplowTracker
  * 
- * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -12,10 +12,6 @@
  * software distributed under the Apache License Version 2.0 is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
- * 
- * Authors: Joshua Beemster, Paul Boocock
- * Copyright: Copyright (c) 2015-2019 Snowplow Analytics Ltd
- * License: Apache License Version 2.0
  */
 
 using System;


### PR DESCRIPTION
Update the years in copyright headers and remove naming authors in some copyrights.