### PR TITLE
Fix logging in Unity Editor (closes #66)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build SnowplowTracker
         working-directory: SnowplowTracker
         run: |
-          dotnet build
+          dotnet build --configuration Release
 
       - name: Insert build files into Unity projects
         working-directory: SnowplowTracker/SnowplowTracker/bin/Debug/netstandard2.0

--- a/SnowplowTracker/SnowplowTracker/Log.cs
+++ b/SnowplowTracker/SnowplowTracker/Log.cs
@@ -29,7 +29,7 @@ namespace SnowplowTracker {
 		/// <param name="message">Message to be logged.</param>
 		public static void Error(string message) {
 			if (logging && level >= 1) {
-#if UNITY_EDITOR
+#if RELEASE
 				UnityEngine.Debug.LogError(message);
 #else
 				Console.Error.WriteLine(message);
@@ -43,7 +43,7 @@ namespace SnowplowTracker {
 		/// <param name="message">Message to be logged.</param>
 		public static void Debug(string message) {
 			if (logging && level >= 2) {
-#if UNITY_EDITOR
+#if RELEASE
 				UnityEngine.Debug.Log(message);
 #else
 				Console.WriteLine(message);
@@ -57,7 +57,7 @@ namespace SnowplowTracker {
 		/// <param name="message">Message to be logged.</param>
 		public static void Verbose(string message) {
 			if (logging && level >= 3) {
-#if UNITY_EDITOR
+#if RELEASE
 				UnityEngine.Debug.Log(message);
 #else
 				Console.WriteLine(message);


### PR DESCRIPTION
As described in the issue #66, Logging does not work as expected in Unity Editor when using the binary dll file. It seems the cause is that we check for the pragma `#if UNITY_EDITOR`, however the dll file is built by dotnet and does not have this pragma attached, so it compiles with `Console.WriteLine()`

Changing the pragma to #if RELEASE and setting the build configuration to Release should fix the problem. Can only be tested in the next release.